### PR TITLE
Fix reproducibility bugs (config should be set)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,32 +1,40 @@
-{ nixpkgsPath ? ./nixpkgs-pinned.nix }:
-(import nixpkgsPath {
-  overlays = [(pkgs: oldpkgs: {
-    haskellPackages =
-      let nix-lib = pkgs.callPackage ./nix-lib {};
-      in oldpkgs.haskellPackages.override {
-        overrides = oldpkgs.lib.composeExtensions
-          (pkgs.callPackage ./nix-lib/old-version-dependencies.nix {})
-          (self: super: {
-            yarn2nix =
-              let
-                pkg = oldpkgs.haskell.lib.overrideCabal
-                  (self.callPackage ./yarn2nix.nix {})
-                  (old: {
-                    prePatch = old.prePatch or "" + ''
-                      ${oldpkgs.lib.getBin self.hpack}/bin/hpack
-                      # we depend on the git prefetcher
-                      substituteInPlace \
-                        src/Distribution/Nixpkgs/Nodejs/ResolveLockfile.hs \
-                        --replace '"nix-prefetch-git"' \
-                          '"${pkgs.nix-prefetch-scripts}/bin/nix-prefetch-git"'
-                    '';
-                  });
-              in oldpkgs.haskell.lib.overrideCabal pkg (old: {
-                src = nix-lib.removePrefixes
-                  [ "nix-lib" "dist" "result" "tests/nix-tests" ] ./.;
-              });
-          });
-      };
-  })];
+{ nixpkgsPath    ? ./nixpkgs-pinned.nix,
+  config         ? {},
+  overlaysBefore ? [],
+  overlaysAfter  ? []
+}:
 
+(import nixpkgsPath {
+  inherit config;
+  overlays = overlaysBefore ++ [
+    (self: super: {
+      haskellPackages = (
+        let nix-lib = self.callPackage ./nix-lib {};
+        in super.haskellPackages.override {
+          overrides = super.lib.composeExtensions
+            (self.callPackage ./nix-lib/old-version-dependencies.nix {})
+            (hself: hsuper: {
+              yarn2nix = (
+                let
+                  pkg = super.haskell.lib.overrideCabal
+                    (hself.callPackage ./yarn2nix.nix {})
+                    (old: {
+                      prePatch = old.prePatch or "" + ''
+                        ${super.lib.getBin hself.hpack}/bin/hpack
+                        # we depend on the git prefetcher
+                        substituteInPlace \
+                          src/Distribution/Nixpkgs/Nodejs/ResolveLockfile.hs \
+                          --replace '"nix-prefetch-git"' \
+                            '"${self.nix-prefetch-scripts}/bin/nix-prefetch-git"'
+                      '';
+                    });
+                in super.haskell.lib.overrideCabal pkg (old: {
+                  src = nix-lib.removePrefixes
+                    [ "nix-lib" "dist" "result" "tests/nix-tests" ] ./.;
+                }));
+            });
+        }
+      );
+    })
+  ] ++ overlaysAfter;
 }).haskellPackages.yarn2nix

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {};
+with import <nixpkgs> { config = {}; overlays = []; };
 (haskellPackages.override {
   overrides = lib.composeExtensions
     (pkgs.callPackage ./nix-lib/old-version-dependencies.nix {})


### PR DESCRIPTION
You should almost always set `config` and `overlays` when calling the `default.nix` in the root of a nixpkgs checkout, otherwise user-provided packageOverrides and overlays can mess with what you are doing.