### PR TITLE
Allow creating a scoped directory if it exists

### DIFF
--- a/nix-lib/default.nix
+++ b/nix-lib/default.nix
@@ -89,7 +89,7 @@ let
           in ''
             echo "linking node dependency ${formatKey dep.key}"
             ${ # we need to create the scope folder, otherwise ln fails
-               lib.optionalString hasScope ''mkdir "${parentfolder}"'' }
+               lib.optionalString hasScope ''mkdir -p "${parentfolder}"'' }
             ln -sT ${dep.drv} "${subfolder}"
             ${yarn2nix}/bin/node-package-tool \
               link-bin \


### PR DESCRIPTION
I was setting up some overrides as described in https://github.com/Profpatsch/yarn2nix/issues/16 and ran into an issue where I had multiple packages under the same scope - `mkdir` failed with `File Exists` on the second package under a given scope. This solves it by adding the `-p` flag to `mkdir`.