### PR TITLE
fix(yarn2nix): on --template generate key set instead of name attr

### DIFF
--- a/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -39,7 +39,7 @@ genTemplate NP.Package{..} =
   simpleParamSet []
   ==> Param nodeDepsSym
   ==> (mkNonRecSet
-        [ "name" $= nameStr
+        [ "key" $= packageKeyToSet (parsePackageKeyName name)
         , "version" $= mkStr version
         , "nodeBuildInputs"  $= (letE "a" (mkSym nodeDepsSym)
                                   $ mkList (map (pkgDep "a") depPkgKeys))
@@ -57,8 +57,10 @@ genTemplate NP.Package{..} =
     depPkgKeys = depsToPkgKeys (dependencies <> devDependencies)
     pkgDep depsSym pk = mkSym depsSym !!. packageKeyToSymbol pk
     nodeDepsSym = "allDeps"
-    nameStr = mkStrQ [StrQ
-      $ pkgKeyToName $ parsePackageKeyName name]
-    pkgKeyToName (YLT.SimplePackageKey n) = n
-    pkgKeyToName (YLT.ScopedPackageKey s n) = s <> "-" <> n
+    packageKeyToSet (YLT.SimplePackageKey n) =
+      packageKeyToSet $ YLT.ScopedPackageKey "" n
+    packageKeyToSet (YLT.ScopedPackageKey s n) = mkNonRecSet $
+      [ bindTo "name"  $ mkStrQ [ StrQ n ]
+      , bindTo "scope" $ mkStrQ [ StrQ s ]
+      ]
     may k v = [k $= mkStr (fromMaybe mempty v)]

--- a/tests/nix-tests/default.nix
+++ b/tests/nix-tests/default.nix
@@ -34,7 +34,10 @@ let
       in [
       # TODO: this is a naïve match, might want to create a better test
       (assertEq "template" tmpl {
-        name = "my-package";
+        key = {
+          name = "my-package";
+          scope = "";
+        };
         version = "1.5.3";
         nodeBuildInputs = [];
         meta = {


### PR DESCRIPTION
Since d607336935c8131872ee97a7f12aa7a0965f63f6 `buildNodePackage` doesn't accept a name argument anymore, but a key one. Due to an oversight in that change `yarn2nix --template` would still generate name attributes which causes `buildNodePackage` to fail if directly used with `callTemplate` and an automatically generated template.

The issue is also described in #25 and should be resolved by this PR (except for the parentheses in README).