### PR TITLE
feat(ci): install nix via nixery.dev container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,13 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    container:
+      image: nixery.dev/shell/nix
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    
-    - uses: cachix/install-nix-action@v10
 
     - uses: cachix/cachix-action@v6
       with:


### PR DESCRIPTION
Github Actions will all actions in a job in the specified container.

With nixery, we have a url-based API for fetching nix containers from
latest nixpkgs stable. It’s not intended for “production” use, but
yarn2nix is so low traffic that @tazjin isn’t even going to notice ;)