### PR TITLE
fix(node-package-tool): default to no (dev) dependencies if unparsable

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,6 @@ dependencies:
   - text == 1.2.*
   - transformers == 0.5.*
   - unordered-containers == 0.2.*
-  - vector == 0.12.*
   - yarn-lock == 0.6.*
 
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
   - text == 1.2.*
   - transformers == 0.5.*
   - unordered-containers == 0.2.*
+  - vector == 0.12.*
   - yarn-lock == 0.6.*
 
 library:

--- a/src/Distribution/Nodejs/Package.hs
+++ b/src/Distribution/Nodejs/Package.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, DeriveGeneric, OverloadedStrings, RecordWildCards, LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude, DeriveGeneric, OverloadedStrings, RecordWildCards, LambdaCase, TypeApplications #-}
 {-|
 Description: Parse and make sense of npm’s @package.json@ project files
 
@@ -24,7 +24,6 @@ import qualified System.FilePath as FP
 import Data.Aeson ((.:), (.:?), (.!=))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as AT
-import qualified Data.Vector as V
 
 -- | npm `package.json`. Not complete.
 --
@@ -99,32 +98,32 @@ instance A.FromJSON LoggingPackage where
     bin             <- parseBin name v
     man             <- l $ parseMan name v
     license         <- tryWarn "license" Nothing
-    dependencies    <- parseDependencies v "dependencies"
-    devDependencies <- parseDependencies v "devDependencies"
+    dependencies    <- tryWarn "dependencies" (AT.Object mempty)
+                         >>= parseDependencies "dependencies"
+    devDependencies <- tryWarn "devDependencies" (AT.Object mempty)
+                         >>= parseDependencies "devDependencies"
     pure Package{..}
     where
 
-      parseDependencies :: AT.Object -> Text -> Warn Dependencies
-      parseDependencies v field =
-        let def = mempty
-        in  lift (v .:? field .!= def) <|>
-           (lift (v .:  field) >>= \val ->
-              case val of
-                -- non empty arrays cause an error
-                AT.Array a ->
-                  if V.null a
-                    then putWarning def
-                      (WrongType { wrongTypeField   = field
-                                 , wrongTypeDefault = Just (show def) })
-                    else fail $ "\"" ++ T.unpack field
-                      ++ "\" is a non empty array instead of a JSON object"
-                -- if we get an object here, it's malformed
-                AT.Object _ -> fail
-                  $ "Could not parse object in \"" ++ T.unpack field ++ "\""
-                -- everything else defaults to mempty and generates a warning
-                _ -> putWarning def
-                       (WrongType { wrongTypeField   = field
-                                  , wrongTypeDefault = Just (show def) }))
+      parseDependencies ::  Text -> AT.Value -> Warn Dependencies
+      parseDependencies field v =
+        let
+          warn = putWarning mempty
+              $ WrongType
+              { wrongTypeField   = field
+              , wrongTypeDefault = Just (show (mempty :: Dependencies)) }
+        in case v of
+          AT.Array a ->
+            -- we interpret empty arrays as just confused users
+            if null a then warn
+            -- however if the user uses a non-empty array,
+            -- they probably mean something which we don’t know how to deal with.
+            else fail
+              $ "\"" ++ T.unpack field ++ "\" is a non empty array instead of a JSON object"
+          -- if we get an object here, it's malformed
+          AT.Object deps -> lift $ traverse (A.parseJSON @Text) deps
+          -- everything else defaults to mempty and generates a warning
+          _ -> warn
 
       parseMapText :: Text -> HML.HashMap Text AT.Value
                    -> Warn (HML.HashMap Text Text)

--- a/tests/TestNpmjsPackage.hs
+++ b/tests/TestNpmjsPackage.hs
@@ -1,17 +1,25 @@
-{-# LANGUAGE OverloadedStrings, TemplateHaskell, QuasiQuotes, NoImplicitPrelude, LambdaCase #-}
+{-# LANGUAGE OverloadedStrings, TemplateHaskell, QuasiQuotes, NoImplicitPrelude, LambdaCase, TypeApplications, RecordWildCards, ScopedTypeVariables #-}
 module TestNpmjsPackage (tests) where
 
 import Protolude
 import Test.Tasty (TestTree)
 import Test.Tasty.TH
-import Test.Tasty.HUnit
+import Test.Tasty.HUnit (Assertion, testCase)
+import qualified Test.Tasty.HUnit as HUnit
 -- import Test.Tasty.QuickCheck
 
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as AT
 import qualified Data.HashMap.Lazy as HML
+import qualified Data.Text as Text
 
 import qualified Distribution.Nodejs.Package as NP
+
+assertEqual :: (HasCallStack, Eq a, Show a) => Text -> a -> a -> Assertion
+assertEqual t a b = HUnit.assertEqual (toS t) a b
+
+assertBool :: (HasCallStack) => Text -> Bool -> Assertion
+assertBool t b = HUnit.assertBool (toS t) b
 
 baseAnd :: [(Text, A.Value)] -> A.Value
 baseAnd fields = A.Object $ HML.fromList $
@@ -29,20 +37,28 @@ parseWithWarningsZoom name got zoom want warningPred =
           assertEqual (toS name) want (zoom val)
           warningPred warnings
 
+formatWarnings :: [NP.Warning] -> Text
+formatWarnings ws = Text.intercalate ", " (map f ws)
+  where
+    f w@(NP.PlainWarning _) = "PlainWarning `" <> NP.formatWarning w <> "`"
+    f w@(NP.WrongType {..}) = "WrongType `" <> NP.formatWarning w <> "`"
+
 parseZoom :: (Eq a, Show a)
           => Text -> A.Value -> (NP.Package -> a) -> a
           -> Assertion
 parseZoom name got zoom want =
-  parseWithWarningsZoom name got zoom want (const $ pure ())
+  parseWithWarningsZoom name got zoom want
+    (\ws -> assertBool ("unexpected warnings: " <> formatWarnings ws ) $ null ws)
 
 data WarningType
   = SomePlainWarning
-  | ExactWrongType
+  | WrongTypeField
     { wrongTypeField :: Text
-    , wrongTypeDefault :: Maybe Text
+    , wrongTypeDefault :: Maybe ()
     }
   deriving (Show)
 
+-- TODO: the warning list should be an exact list/set!
 hasWarning :: WarningType -> [NP.Warning] -> Assertion
 hasWarning t = assertBool ("no such warning: " <> show t)
                . any (checkWarningType t)
@@ -50,12 +66,55 @@ hasWarning t = assertBool ("no such warning: " <> show t)
 checkWarningType :: WarningType -> NP.Warning -> Bool
 checkWarningType tp w = case (tp, w) of
   (SomePlainWarning, NP.PlainWarning _) -> True
-  ( ExactWrongType { wrongTypeField = ft
+  ( WrongTypeField { wrongTypeField = ft
                    , wrongTypeDefault = deft },
     NP.WrongType { NP.wrongTypeField = f
                  , NP.wrongTypeDefault = def })
-    -> ft == f && deft == def
+    -> ft == f && case (deft, def) of
+        (Nothing, Nothing) -> True
+        (Just (), Just _) -> True
+        _ -> False
   (_, _) -> False
+
+case_dependencies :: Assertion
+case_dependencies = do
+  parseZoom "dependencies are missing"
+            (baseAnd [ ])
+            NP.dependencies
+            mempty
+
+  parseZoom "dependencies are empty"
+            (baseAnd [ ("dependencies", A.object []) ])
+            NP.dependencies
+            mempty
+
+  parseZoom "some dependencies"
+            (baseAnd [ ("dependencies", A.object
+                       [ ("foo", "1.2.3")
+                       , ("bar", "3.4.0") ]) ])
+            NP.dependencies
+            (HML.fromList
+              [ ("foo", "1.2.3")
+              , ("bar", "3.4.0") ])
+
+  parseWithWarningsZoom "dependencies are an empty list"
+            (baseAnd [ ("dependencies", A.Array mempty) ])
+            NP.dependencies
+            mempty
+            (hasWarning $ WrongTypeField
+              { wrongTypeField = "dependencies"
+              , wrongTypeDefault = Just () })
+
+  parseWithWarningsZoom "dependencies is a random scalar"
+            (baseAnd [ ("dependencies", A.String "hiho") ])
+            NP.dependencies
+            mempty
+            (hasWarning $ WrongTypeField
+              { wrongTypeField = "dependencies"
+              , wrongTypeDefault = Just () })
+
+  parseFailure (Proxy @NP.LoggingPackage) "dependencies are a non-empty list"
+            (baseAnd [ ("dependencies", A.Array (pure "foo")) ])
 
 case_binPaths :: Assertion
 case_binPaths = do
@@ -97,17 +156,20 @@ case_binPaths = do
                                    , ("bar", "imascript") ]) ])
                         NP.scripts
                         (HML.fromList [ ("bar", "imascript") ])
-                        (hasWarning (ExactWrongType "scripts.foo" Nothing))
+                        (hasWarning (WrongTypeField
+                           { wrongTypeField = "scripts.foo"
+                           , wrongTypeDefault = Nothing }))
 
 parseSuccess :: (A.FromJSON a) => A.Value -> IO a
 parseSuccess v = case A.fromJSON v of
-  (AT.Error err) -> assertFailure err >> panic "not reached"
+  (AT.Error err) -> HUnit.assertFailure err >> panic "not reached"
   (AT.Success a) -> pure a
 
--- parseFailure :: Show a => (A.Value -> AT.Parser a) -> A.Value -> IO ()
--- parseFailure p v = case AT.parse p v of
---   (AT.Error _) -> pass
---   (AT.Success a) -> assertFailure $ "no parse" <> show a
+parseFailure :: forall a. (A.FromJSON a) => Proxy a -> Text -> A.Value -> IO ()
+parseFailure Proxy msg v = case AT.fromJSON @a v of
+  -- TODO: check the error?
+  (AT.Error _) -> pass
+  (AT.Success _) -> HUnit.assertFailure $ (toS msg) <> ", parse should have failed."
 
 tests :: TestTree
 tests = $(testGroupGenerator)


### PR DESCRIPTION
In the node world you can't depend on anything, especially not that a certain field of `package.json` is well-formed.

Since the `dependencies` field is sometimes malformed we default to `{}`. I think packages with malformed `dependencies` field can't reasonably expect their dependencies to be installed correctly.

A negative side effect of this change could be that it'd be hard to debug such an error, since `node-package-tool` will only output a warning getting drowned out be other output of `nix`. This *should* not be an issue however since people won't necessarily use `yarn2nix` for development, so if `yarn` itself behaves similarly the issue would be spotted earlier hopefully.

To demonstrate the original issue apply this [patch](https://gist.github.com/sternenseemann/bdb4b7c5d066f70f670ac09211213320) in [CodiMD/server](https://github.com/codimd/server) and try to build it with `master` `yarn2nix`. Then the issue is triggered by <https://github.com/garycourt/JSV/blob/master/package.json#L29> being a empty array instead of a empty dictionary.