### PR TITLE
feat(default.nix): statically build and add documentation and nixLib

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,9 @@ Then use the library to assemble the generated files in a `default.nix`:
 
 ```nix
 let
-  nixpkgsPath = /path/to/yarn2nix/nixpkgs-pinned.nix;
-  pkgs = import nixpkgsPath {};
-  nixLib = pkgs.callPackage /path/to/yarn2nix/nix-lib {
-    # WARNING (TODO): for now yarn2nix is built with a pinned
-    # version of nixpkgs to prevent breakage
-    yarn2nix = import /path/to/yarn2nix { inherit nixpkgsPath; };
-  };
+  pkgs = import <nixpkgs> {};
+  yarn2nix = import /path/to/yarn2nix {};
+  nixLib = yarn2nix.nixLib;
 
 in
   nixLib.buildNodePackage

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,6 @@
-{ nixpkgsPath ? ./nixpkgs-pinned.nix }:
+{ pkgs ? import ./nixpkgs-pinned.nix {} }:
 
 let
-  pkgs = import nixpkgsPath {};
   lib = pkgs.lib;
 
   haskellPackages = pkgs.haskellPackages.override {
@@ -75,6 +74,11 @@ let
         }} "$doc/share/yarn2nix"
        ${pkgs.skawarePackages.cleanPackaging.checkForRemainingFiles}
      '';
+
+     passthru.nixLib = import ./nix-lib {
+       inherit lib pkgs;
+       inherit yarn2nix;
+     };
    };
 
 in yarn2nix

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ let
                   substituteInPlace \
                     src/Distribution/Nixpkgs/Nodejs/ResolveLockfile.hs \
                     --replace '"nix-prefetch-git"' \
-                      '"${pkgs.nix-prefetch-scripts}/bin/nix-prefetch-git"'
+                      '"${pkgs.nix-prefetch-git.override { git = pkgs.gitMinimal; }}/bin/nix-prefetch-git"'
                 '';
               });
           in pkgs.haskell.lib.overrideCabal pkg (old: {

--- a/tests/nix-tests/default.nix
+++ b/tests/nix-tests/default.nix
@@ -1,9 +1,8 @@
-{ nixpkgsPath ? ../../nixpkgs-pinned.nix
+{ pkgs ? import ../../nixpkgs-pinned.nix {}
 , nixLibPath ? ../../nix-lib
-, yarn2nix ? import ../../. { inherit nixpkgsPath; }
+, yarn2nix ? import ../../. { inherit pkgs; }
 }:
 let
-  pkgs = import nixpkgsPath {};
   nixLib = pkgs.callPackage nixLibPath {
     inherit yarn2nix;
   };


### PR DESCRIPTION
Creates multiple outputs, makes sure all docs are in the doc
directory, (semi-)statically builds the binaries, puts the nix-lib
directory into the `nixLib` output.