### PR TITLE
feat(yarn2nix): arg parsing using optparse-applicative 

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,41 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Protolude
 import Distribution.Nixpkgs.Nodejs.Cli (cli)
-import Distribution.Nixpkgs.Nodejs.RunConfig
-import Options.Applicative
-import Options.Applicative.Help.Pretty (linebreak)
 
 main :: IO ()
-main = execParser (info (runConfigParser <**> helper) desc) >>= cli
-
-desc :: InfoMod a
-desc = fullDesc
-  <> progDescDoc (Just $ mconcat $ intersperse linebreak
-   [ "yarn2nix has two modes:"
-   <> linebreak
-   , "In its default mode (started without --template) it parses a given yarn.lock file"
-   , "and prints a nix expressions representing it to stdout."
-   <> linebreak
-   , "If --template is given, it processes a given package.json"
-   , "and prints a template nix expression for an equivalent nix package."
-   <> linebreak
-   , "In both modes yarn2nix will take the file as an argument"
-   , "or read it from stdin if it is missing."
-   ])
-
--- If --template is given, run in NodeTemplate mode,
--- otherwise the default mode YarnLock is used.
-runModeParser :: Parser RunMode
-runModeParser = flag YarnLock NodeTemplate $
-     long "template"
-  <> help "Output a nix package template for a given package.json"
-
-runConfigParser :: Parser RunConfig
-runConfigParser = RunConfig
-  <$> runModeParser
-  <*> switch
-      (long "offline"
-    <> help "Makes yarn2nix fail if network access is required")
-  <*> optional (argument str (metavar "FILE"))
+main = cli

--- a/Main.hs
+++ b/Main.hs
@@ -1,10 +1,34 @@
 module Main where
 
 import Distribution.Nixpkgs.Nodejs.Cli (cli)
-import qualified Data.Text as T
-import System.Environment (getArgs)
+import Distribution.Nixpkgs.Nodejs.RunConfig
+import Options.Applicative
 
 main :: IO ()
-main = getArgs >>= cli . map T.pack
+main = execParser (info (runConfigParser <**> helper) desc) >>= cli
 
+desc :: InfoMod a
+desc = fullDesc
+  <> progDesc (mconcat
+   [ "yarn2nix has two modes: "
+   , "In its default mode (started without --template) it parses a given "
+   , "yarn.lock file and prints a nix expressions representing it to stdout. "
+   , "If --template is given, it processes a given package.json and prints a "
+   , "template nix expression for an equivalent nix package. "
+   , "In both modes yarn2nix will take the file as an argument or read it from "
+   , "stdin if it is missing." ])
 
+-- If --template is given, run in NodeTemplate mode,
+-- otherwise the default mode YarnLock is used.
+runModeParser :: Parser RunMode
+runModeParser = flag YarnLock NodeTemplate $
+     long "template"
+  <> help "Output a nix package template for a given package.json"
+
+runConfigParser :: Parser RunConfig
+runConfigParser = RunConfig
+  <$> runModeParser
+  <*> switch
+      (long "offline"
+    <> help "Makes yarn2nix fail if network access is required")
+  <*> optional (argument str (metavar "FILE"))

--- a/Main.hs
+++ b/Main.hs
@@ -1,22 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import Protolude
 import Distribution.Nixpkgs.Nodejs.Cli (cli)
 import Distribution.Nixpkgs.Nodejs.RunConfig
 import Options.Applicative
+import Options.Applicative.Help.Pretty (linebreak)
 
 main :: IO ()
 main = execParser (info (runConfigParser <**> helper) desc) >>= cli
 
 desc :: InfoMod a
 desc = fullDesc
-  <> progDesc (mconcat
-   [ "yarn2nix has two modes: "
-   , "In its default mode (started without --template) it parses a given "
-   , "yarn.lock file and prints a nix expressions representing it to stdout. "
-   , "If --template is given, it processes a given package.json and prints a "
-   , "template nix expression for an equivalent nix package. "
-   , "In both modes yarn2nix will take the file as an argument or read it from "
-   , "stdin if it is missing." ])
+  <> progDescDoc (Just $ mconcat $ intersperse linebreak
+   [ "yarn2nix has two modes:"
+   <> linebreak
+   , "In its default mode (started without --template) it parses a given yarn.lock file"
+   , "and prints a nix expressions representing it to stdout."
+   <> linebreak
+   , "If --template is given, it processes a given package.json"
+   , "and prints a template nix expression for an equivalent nix package."
+   <> linebreak
+   , "In both modes yarn2nix will take the file as an argument"
+   , "or read it from stdin if it is missing."
+   ])
 
 -- If --template is given, run in NodeTemplate mode,
 -- otherwise the default mode YarnLock is used.

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - transformers == 0.5.*
   - unordered-containers == 0.2.*
   - yarn-lock == 0.6.*
+  - optparse-applicative >= 0.13 && < 0.16
 
 library:
   source-dirs: src
@@ -50,7 +51,6 @@ executables:
     main: Main.hs
     dependencies:
       - yarn2nix
-      - optparse-applicative >= 0.13
   node-package-tool:
     main: NodePackageTool.hs
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -50,11 +50,11 @@ executables:
     main: Main.hs
     dependencies:
       - yarn2nix
-      - optparse-applicative >= 0.13 && < 0.15
+      - optparse-applicative >= 0.13
   node-package-tool:
     main: NodePackageTool.hs
     dependencies:
-      - optparse-applicative >= 0.13 && < 0.15
+      - optparse-applicative >= 0.13
       - unix == 2.7.*
       - yarn2nix
 

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ executables:
     main: Main.hs
     dependencies:
       - yarn2nix
+      - optparse-applicative >= 0.13 && < 0.15
   node-package-tool:
     main: NodePackageTool.hs
     dependencies:

--- a/src/Distribution/Nixpkgs/Nodejs/Cli.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/Cli.hs
@@ -11,10 +11,13 @@ import Protolude
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import qualified Options.Applicative as O
+import qualified Options.Applicative.Help.Pretty as O (linebreak)
 import qualified System.Directory as Dir
+import System.Environment (getProgName)
 
 import qualified Nix.Pretty as NixP
-import Data.Text.Prettyprint.Doc.Render.Text (putDoc)
+import qualified Data.Text.Prettyprint.Doc.Render.Text as RT
 import qualified Yarn.Lock as YL
 import qualified Yarn.Lock.Types as YLT
 import qualified Yarn.Lock.Helpers as YLH
@@ -25,15 +28,36 @@ import qualified Distribution.Nixpkgs.Nodejs.ResolveLockfile as Res
 import qualified Distribution.Nodejs.Package as NP
 import Distribution.Nixpkgs.Nodejs.RunConfig
 
+description :: O.InfoMod a
+description = O.fullDesc
+  <> O.progDescDoc (Just $ mconcat $ intersperse O.linebreak
+   [ "yarn2nix has two modes:"
+   <> O.linebreak
+   , "In its default mode (started without --template) it parses a given yarn.lock file"
+   , "and prints a nix expressions representing it to stdout."
+   <> O.linebreak
+   , "If --template is given, it processes a given package.json"
+   , "and prints a template nix expression for an equivalent nix package."
+   <> O.linebreak
+   , "In both modes yarn2nix will take the file as an argument"
+   , "or read it from stdin if it is missing."
+   ])
+
+-- | Main entry point for @yarn2nix@.
+cli :: IO ()
+cli = parseOpts >>= runAction
+
 fileFor :: RunConfig -> Text
 fileFor cfg =
   case runMode cfg of
     YarnLock -> "yarn.lock"
     NodeTemplate -> "package.json"
 
--- | Main entry point for @yarn2nix@.
-cli :: RunConfig -> IO ()
-cli cfg = do
+parseOpts :: IO RunConfig
+parseOpts = O.customExecParser optparsePrefs runConfigParserWithHelp
+
+runAction :: RunConfig -> IO ()
+runAction cfg = do
   file <- fileForConfig
   case runMode cfg of
     YarnLock -> parseYarn file
@@ -45,7 +69,7 @@ cli cfg = do
         Just f -> pure f
         Nothing -> Dir.getCurrentDirectory >>= \d ->
           Dir.findFile [d] (toS $ fileFor cfg) >>= \case
-            Nothing -> die'
+            Nothing -> dieWithUsage
               $ "No " <> fileFor cfg <> " found in current directory"
             Just path -> pure path
     parseYarn :: FilePath -> IO ()
@@ -53,7 +77,7 @@ cli cfg = do
       let pathT = toS path
       fc <- readFile path
         `catch` \e
-          -> die' ("Unable to open " <> pathT <> ":\n" <> show (e :: IOException))
+          -> dieWithUsage ("Unable to open " <> pathT <> ":\n" <> show (e :: IOException))
       case YL.parse path fc of
         Right yarnfile  -> toStdout cfg yarnfile
         Left err -> die' ("Could not parse " <> pathT <> ":\n" <> show err)
@@ -65,8 +89,44 @@ cli cfg = do
           print $ NixP.prettyNix $ NodeFP.genTemplate nodeModule
         Left err -> die' ("Could not parse " <> toS path <> ":\n" <> show err)
 
+-- get rid of odd linebreaks by increasing width enough
+optparsePrefs :: O.ParserPrefs
+optparsePrefs = O.defaultPrefs { O.prefColumns = 100 }
+
+-- If --template is given, run in NodeTemplate mode,
+-- otherwise the default mode YarnLock is used.
+runModeParser :: O.Parser RunMode
+runModeParser = O.flag YarnLock NodeTemplate $
+     O.long "template"
+  <> O.help "Output a nix package template for a given package.json"
+
+runConfigParser :: O.Parser RunConfig
+runConfigParser = RunConfig
+  <$> runModeParser
+  <*> O.switch
+      (O.long "offline"
+    <> O.help "Makes yarn2nix fail if network access is required")
+  <*> O.optional (O.argument O.str (O.metavar "FILE"))
+
+runConfigParserWithHelp :: O.ParserInfo RunConfig
+runConfigParserWithHelp =
+  O.info (runConfigParser <**> O.helper) description
+ 
 die' :: Text -> IO a
 die' err = putErrText err *> exitFailure
+
+-- TODO from optparse-applicative 0.16.0.0 ShowHelpText
+-- accepts an error message as argument, so we can use
+-- that instead of putErrText.
+dieWithUsage :: Text -> IO a
+dieWithUsage err = do
+  putErrText (err <> "\n")
+  progn <- getProgName
+  hPutStr stderr
+    . fst . flip O.renderFailure progn
+    $ O.parserFailure optparsePrefs
+        runConfigParserWithHelp O.ShowHelpText mempty
+  exitFailure
 
 -- TODO refactor
 toStdout :: RunConfig -> YLT.Lockfile -> IO ()
@@ -80,4 +140,4 @@ toStdout cfg lf = do
     Left err -> die' (T.intercalate "\n" $ toList err)
     Right res -> pure res
   -- killThread thrd
-  putDoc $ NixP.prettyNix $ NixOut.mkPackageSet $ NixOut.convertLockfile lf'
+  RT.putDoc $ NixP.prettyNix $ NixOut.mkPackageSet $ NixOut.convertLockfile lf'

--- a/src/Distribution/Nixpkgs/Nodejs/RunConfig.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/RunConfig.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-|
+Description: Invocation Configuration
+-}
+module Distribution.Nixpkgs.Nodejs.RunConfig
+  ( RunConfig (..)
+  , RunMode (..)
+  ) where
+
+import Protolude
+
+-- | Type of action @yarn2nix@ is performing.
+data RunMode
+  = YarnLock     -- ^ Output a nix expression for a @yarn.lock@
+  | NodeTemplate -- ^ Output a nix template corresponding to a @package.json@
+  deriving (Show, Eq)
+
+-- | Runtime configuration of @yarn2nix@. Typically this is determined from
+--   its command line arguments and valid for the current invocation only.
+data RunConfig
+  = RunConfig
+  { runMode         :: RunMode
+  , runOffline      :: Bool            -- ^ If @True@, @yarn2nix@ will fail if it
+                                       --   requires network access. Currently this means
+                                       --   'Distribution.Nixpkgs.Nodejs.ResolveLockfile.resolveLockfileStatus'
+                                       --   will throw an error in case resolving a hash
+                                       --   requires network access.
+  , runInputFile    :: Maybe FilePath  -- ^ File to process. If missing the appropriate
+                                       --   file for the current mode from the current
+                                       --   working directory is used.
+  } deriving (Show, Eq)

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -1,35 +1,34 @@
-{ mkDerivation, aeson, ansi-wl-pprint, async-pool, base, bytestring
-, containers, data-fix, directory, either, filepath, hnix
-, http-client, http-client-tls, monad-par, mtl, neat-interpolation
-, optparse-applicative, process, protolude, regex-tdfa
-, regex-tdfa-text, stdenv, stm, tasty, tasty-hunit
-, tasty-quickcheck, tasty-th, text, unix, unordered-containers
-, yarn-lock
+{ mkDerivation, aeson, async-pool, base, bytestring, containers
+, data-fix, directory, filepath, hnix, mtl
+, neat-interpolation, optparse-applicative, prettyprinter, process
+, protolude, regex-tdfa, regex-tdfa-text, stdenv, stm, tasty
+, tasty-hunit, tasty-quickcheck, tasty-th, text, transformers, unix
+, unordered-containers, yarn-lock
 }:
 mkDerivation {
   pname = "yarn2nix";
-  version = "0.6.0";
+  version = "0.8.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson ansi-wl-pprint async-pool base bytestring containers data-fix
-    directory either filepath hnix http-client http-client-tls
-    monad-par mtl process protolude regex-tdfa regex-tdfa-text stm text
+    aeson async-pool base bytestring containers data-fix directory
+    filepath hnix mtl optparse-applicative prettyprinter process
+    protolude regex-tdfa regex-tdfa-text stm text transformers
     unordered-containers yarn-lock
   ];
   executableHaskellDepends = [
-    aeson ansi-wl-pprint async-pool base bytestring containers data-fix
-    directory either filepath hnix http-client http-client-tls
-    monad-par mtl optparse-applicative process protolude regex-tdfa
-    regex-tdfa-text stm text unix unordered-containers yarn-lock
+    aeson async-pool base bytestring containers data-fix directory
+    filepath hnix mtl optparse-applicative prettyprinter process
+    protolude regex-tdfa regex-tdfa-text stm text transformers unix
+    unordered-containers yarn-lock
   ];
   testHaskellDepends = [
-    aeson ansi-wl-pprint async-pool base bytestring containers data-fix
-    directory either filepath hnix http-client http-client-tls
-    monad-par mtl neat-interpolation process protolude regex-tdfa
-    regex-tdfa-text stm tasty tasty-hunit tasty-quickcheck tasty-th
-    text unordered-containers yarn-lock
+    aeson async-pool base bytestring containers data-fix directory
+    filepath hnix mtl neat-interpolation optparse-applicative
+    prettyprinter process protolude regex-tdfa regex-tdfa-text stm
+    tasty tasty-hunit tasty-quickcheck tasty-th text transformers
+    unordered-containers yarn-lock
   ];
   homepage = "https://github.com/Profpatsch/yarn2nix#readme";
   description = "Convert yarn.lock files to nix expressions";


### PR DESCRIPTION
This adds backwards compatible arg parsing via `optparse-applicative` which can be used for both actions. It has slightly less usability to reduced quality in help messages, but should be more extensible.

Main motivation is creating the possibility to add new flags (for another feature for `--template`) without increasing the mess in `cli`.

---

```
Unify runtime "configuration" mechanism: We now generate a RunConfig
from the command line and pass it to cli. This config is used to
determine which action to take (template / lock file) via RunMode
and contains additional information to influence runtime behavior
like runOffline.

The configuration can be passed to both actions if necessary, mandatory
action specific flags / variables could be hidden away in RunMode in the
future.
```
