### PR TITLE
feat(yarn2nix): output proper license sets when using --template

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,9 @@
 let
   lib = pkgs.lib;
 
+  licensesJson =
+    pkgs.writeText "licenses.json" (builtins.toJSON lib.licenses);
+
   haskellPackages = pkgs.haskellPackages.override {
     overrides = lib.composeExtensions
       (pkgs.callPackage ./nix-lib/old-version-dependencies.nix {})
@@ -76,9 +79,13 @@ let
        ${pkgs.skawarePackages.cleanPackaging.checkForRemainingFiles}
      '';
 
-     passthru.nixLib = import ./nix-lib {
-       inherit lib pkgs;
-       inherit yarn2nix;
+     passthru = {
+       nixLib = import ./nix-lib {
+         inherit lib pkgs;
+         inherit yarn2nix;
+       };
+
+       inherit licensesJson;
      };
    };
 

--- a/src/Distribution/Nixpkgs/Nodejs/Cli.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/Cli.hs
@@ -114,7 +114,7 @@ runConfigParser = RunConfig
   <*> O.optional (O.option O.str
      (O.long "license-data"
    <> O.metavar "FILE"
-   <> O.help "Path to a license.json equivalent to lib.licenses from nixpkgs"))
+   <> O.help "Path to a license.json equivalent to nixpkgs.lib.licenses"))
   <*> O.optional (O.argument O.str (O.metavar "FILE"))
 
 runConfigParserWithHelp :: O.ParserInfo RunConfig

--- a/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -12,7 +12,7 @@ import qualified Data.HashMap.Lazy as HML
 import Nix.Expr
 import Nix.Expr.Additions
 
-import Distribution.Nixpkgs.Nodejs.Utils (packageKeyToSymbol)
+import Distribution.Nixpkgs.Nodejs.Utils (packageKeyToSymbol, attrSetMayStr)
 import qualified Distribution.Nodejs.Package as NP
 import qualified Yarn.Lock.Types as YLT
 
@@ -44,9 +44,9 @@ genTemplate NP.Package{..} =
         , "nodeBuildInputs"  $= (letE "a" (mkSym nodeDepsSym)
                                   $ mkList (map (pkgDep "a") depPkgKeys))
         , "meta"      $= (mkNonRecSet
-           $ may "description" description
-          <> may "license" license
-          <> may "homepage" homepage)
+           $ attrSetMayStr "description" description
+          <> attrSetMayStr "license" license
+          <> attrSetMayStr "homepage" homepage)
         ])
   where
     -- TODO: The devDependencies are only needed for the build
@@ -63,4 +63,3 @@ genTemplate NP.Package{..} =
       [ bindTo "name"  $ mkStrQ [ StrQ n ]
       , bindTo "scope" $ mkStrQ [ StrQ s ]
       ]
-    may k v = maybeToList $ (k $=) . mkStr <$> v

--- a/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -12,8 +12,9 @@ import qualified Data.HashMap.Lazy as HML
 import Nix.Expr
 import Nix.Expr.Additions
 
-import Distribution.Nixpkgs.Nodejs.Utils (packageKeyToSymbol, attrSetMayStr)
+import Distribution.Nixpkgs.Nodejs.Utils (packageKeyToSymbol, attrSetMayStr, attrSetMay)
 import qualified Distribution.Nodejs.Package as NP
+import qualified Distribution.Nixpkgs.Nodejs.License as NL
 import qualified Yarn.Lock.Types as YLT
 
 
@@ -33,8 +34,8 @@ parsePackageKeyName k =
 -- | generate a nix expression that translates your package.nix
 --
 -- and can serve as template for manual adjustments
-genTemplate :: NP.Package -> NExpr
-genTemplate NP.Package{..} =
+genTemplate :: Maybe NL.LicensesBySpdxId -> NP.Package -> NExpr
+genTemplate licSet NP.Package{..} =
   -- reserved for possible future arguments (to prevent breakage)
   simpleParamSet []
   ==> Param nodeDepsSym
@@ -45,7 +46,7 @@ genTemplate NP.Package{..} =
                                   $ mkList (map (pkgDep "a") depPkgKeys))
         , "meta"      $= (mkNonRecSet
            $ attrSetMayStr "description" description
-          <> attrSetMayStr "license" license
+          <> attrSetMay    "license" (NL.nodeLicenseToNixpkgs license licSet)
           <> attrSetMayStr "homepage" homepage)
         ])
   where

--- a/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -63,4 +63,4 @@ genTemplate NP.Package{..} =
       [ bindTo "name"  $ mkStrQ [ StrQ n ]
       , bindTo "scope" $ mkStrQ [ StrQ s ]
       ]
-    may k v = [k $= mkStr (fromMaybe mempty v)]
+    may k v = maybeToList $ (k $=) . mkStr <$> v

--- a/src/Distribution/Nixpkgs/Nodejs/License.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/License.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, RecordWildCards, FlexibleInstances, GeneralizedNewtypeDeriving #-}
+{-|
+Description: Convert @package.json@ license fields to nixpkgs license attribute sets
+-}
+module Distribution.Nixpkgs.Nodejs.License
+  ( -- * Conversion Logic
+    nodeLicenseToNixpkgs
+    -- * License Set Representation
+  , NixpkgsLicense (..)
+  , unfreeLicense
+    -- * License Lookup Table
+  , decode
+  , LicensesBySpdxId (..)
+  , lookupSpdxId
+  ) where
+
+import Protolude
+
+import Data.Aeson ((.:), (.:?))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as AT
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.HashMap.Lazy as HML
+import Nix.Expr
+import Distribution.Nixpkgs.Nodejs.Utils (attrSetMay, attrSetMayStr)
+
+-- newtype to circumvent the default instance: we don't want
+-- the key of the JSON object to be the key of the HashMap,
+-- but one of its values (spdxId).
+-- | Lookup table from SPDX identifier (as 'Text') to 'NixpkgsLicense'.
+--
+--   Should be obtained using 'decode'.
+newtype LicensesBySpdxId
+  = LicensesBySpdxId { unLicensesBySpdxId :: HML.HashMap Text NixpkgsLicense }
+  deriving (Show, Eq, Semigroup, Monoid)
+
+-- | Representation of a nixpkgs license set as found in
+--   @lib.licenses@. There doesn't seem to be a strict
+--   definition of what is required and what is optional,
+--   the distribution of 'Maybe' and non-'Maybe' values
+--   is based on the current situation in @lib/licenses.nix@.
+data NixpkgsLicense
+  = NixpkgsLicense
+  { attrName  :: Text       -- ^ Attribute name of the license in @lib.licenses@
+  , shortName :: Text
+  , spdxId    :: Maybe Text
+  , fullName  :: Text
+  , url       :: Maybe Text
+  , free      :: Maybe Bool
+  } deriving (Show, Eq)
+
+-- | Static version of @lib.licenses.unfree@,
+--   so @UNLICENSED@ can be handled correctly
+--   even if no lookup table is provided.
+unfreeLicense :: NixpkgsLicense
+unfreeLicense = NixpkgsLicense
+  { attrName = "unfree"
+  , shortName = "unfree"
+  , fullName = "Unfree"
+  , free = Just False
+  , spdxId = Nothing
+  , url = Nothing
+  }
+
+instance A.FromJSON LicensesBySpdxId where
+  parseJSON = A.withObject "NixpkgsLicenseSet" $
+    HMS.foldrWithKey (\k v p -> p >>= addNixpkgsLicense k v) (pure mempty)
+
+addNixpkgsLicense :: Text -> AT.Value -> LicensesBySpdxId -> AT.Parser LicensesBySpdxId
+addNixpkgsLicense attr val lics = do
+  license <- A.withObject "NixpkgsLicense" parseLicense val
+  let (LicensesBySpdxId licsMap) = lics
+  -- insert if it has an spdxId, otherwise just return lics
+  case spdxId license of
+    Nothing -> pure lics
+    Just i -> pure $ LicensesBySpdxId $ HML.insert i license licsMap
+  where parseLicense v = NixpkgsLicense
+          <$> pure attr
+          <*> v .:  "shortName"
+          <*> v .:? "spdxId"
+          <*> v .:  "fullName"
+          <*> v .:? "url"
+          <*> v .:? "free"
+
+-- | Build nix attribute set for given 'NixpkgsLicense'.
+--
+--   The resulting nix value of @nixpkgsLicenseExpression x@
+--   should be equal to @lib.licenses.<attrName x>@ for the
+--   same version of nixpkgs used.
+nixpkgsLicenseExpression :: NixpkgsLicense -> NExpr
+nixpkgsLicenseExpression (NixpkgsLicense{..}) = mkNonRecSet $
+  [ "fullName" $= mkStr fullName
+  , "shortName" $= mkStr shortName ]
+  <> attrSetMayStr "spdxId" spdxId
+  <> attrSetMayStr "url" url
+  <> attrSetMay "free" (mkBool <$> free)
+
+-- | Implements the logic for converting from an (optional)
+--   @package.json@ @license@ field to a nixpkgs @meta.license@
+--   set. Since support for multiple licenses is poor in nixpkgs
+--   at the moment, we don't attempt to convert SPDX expressions
+--   like @(ISC OR GPL-3.0-only)@.
+--
+--   See <https://docs.npmjs.com/files/package.json#license> for
+--   details on npm's @license@ field.
+nodeLicenseToNixpkgs :: Maybe Text -> Maybe LicensesBySpdxId -> Maybe NExpr
+nodeLicenseToNixpkgs nodeLicense licSet = do
+  id <- nodeLicense
+  if id == "UNLICENSED"
+    then pure $ nixpkgsLicenseExpression unfreeLicense
+    else (lookupSpdxId id =<< licSet) <|> pure (mkStr id)
+
+-- | Lookup function for 'LicensesBySpdxId' which directly returns a 'NExpr'.
+--   This function only looks up by SPDX identifier and does not take
+--   npm-specific quirks into account.
+--
+--   Use 'nodeLicenseToNixpkgs' when dealing with the @license@ field
+--   of a npm-ish javascript package.
+lookupSpdxId :: Text -> LicensesBySpdxId -> Maybe NExpr
+lookupSpdxId lic licSet =
+  nixpkgsLicenseExpression <$> HML.lookup lic (unLicensesBySpdxId licSet)
+
+-- | Build lookup table from a @licenses.json@ file which has been
+--   built by @writeText "licenses.json" (builtins.toJSON lib.licenses)@.
+--
+--   Reexport from aeson.
+decode :: BL.ByteString -> Maybe LicensesBySpdxId
+decode = A.decode

--- a/src/Distribution/Nixpkgs/Nodejs/RunConfig.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/RunConfig.hs
@@ -25,6 +25,9 @@ data RunConfig
                                        --   'Distribution.Nixpkgs.Nodejs.ResolveLockfile.resolveLockfileStatus'
                                        --   will throw an error in case resolving a hash
                                        --   requires network access.
+  , runLicensesJson :: Maybe FilePath  -- ^ Optional Path to a licenses.json file
+                                       --   equivalent to the lib.licenses set from
+                                       --   @nixpkgs@.
   , runInputFile    :: Maybe FilePath  -- ^ File to process. If missing the appropriate
                                        --   file for the current mode from the current
                                        --   working directory is used.

--- a/src/Distribution/Nixpkgs/Nodejs/Utils.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/Utils.hs
@@ -4,6 +4,7 @@ Description: Misc utils
 -}
 module Distribution.Nixpkgs.Nodejs.Utils where
 import Protolude
+import Nix.Expr
 import qualified Yarn.Lock.Types as YLT
 
 -- | Representation of a PackageKey as nix attribute name.
@@ -19,3 +20,13 @@ packageKeyNameToSymbol = \case
   YLT.ScopedPackageKey scope n -> "@" <> scope <> "/" <> n
 {-# INLINABLE packageKeyNameToSymbol #-}
 
+-- | Return a 'Binding' if 'Just' (or none if 'Nothing')
+--   for 'mkRecSet' and 'mkNonRecSet'.
+attrSetMay :: Text -> Maybe NExpr -> [Binding NExpr]
+attrSetMay k v = maybeToList $ (k $=) <$> v
+{-# INLINABLE attrSetMay #-}
+
+-- | Convenience shortcut for @'attrSetMay' x (mkStr \<$\> y)@.
+attrSetMayStr :: Text -> Maybe Text -> [Binding NExpr]
+attrSetMayStr k = attrSetMay k . fmap mkStr
+{-# INLINABLE attrSetMayStr #-}

--- a/tests/nix-tests/default.nix
+++ b/tests/nix-tests/default.nix
@@ -55,11 +55,7 @@ let
         };
         version = "1.5.3";
         nodeBuildInputs = [];
-        meta = {
-          description = "";
-          homepage = "";
-          license = "";
-        };
+        meta = { };
       })
     ]))
     (it "checks the readme example"

--- a/tests/nix-tests/default.nix
+++ b/tests/nix-tests/default.nix
@@ -43,14 +43,6 @@ let
     '';
   };
 
-  # convert a package.json to yarn2nix package template
-  template = package-json: pkgs.runCommandLocal "generate-template" {} ''
-    ${yarn2nix}/bin/yarn2nix --license-data ${yarn2nix.passthru.licensesJson} \
-      --template ${package-json} > $out
-    echo "template for ${package-json} is:" >&2
-    cat $out >&2
-  '';
-
   # generates nix expression for license with a given spdx id and imports it
   spdxLicenseSet = spdx:
     let
@@ -59,13 +51,13 @@ let
         version = "0.1.0";
         license = spdx;
       });
-      tpl = import (template packageJson) {} {};
+      tpl = nixLib.callPackageJson packageJson {} {};
     in tpl.meta.license;
 
   # test suite
   tests = runTestsuite "yarn2nix" [
     (it "checks the template output"
-      (let tmpl = import (template my-package-json) {} {};
+      (let tmpl = nixLib.callPackageJson my-package-json {} {};
       in [
       # TODO: this is a naïve match, might want to create a better test
       (assertEq "template" tmpl {

--- a/tests/nix-tests/default.nix
+++ b/tests/nix-tests/default.nix
@@ -17,6 +17,7 @@ let
   my-package-json = pkgs.writeText "package.json" (builtins.toJSON {
     name = "my-package";
     version = "1.5.3";
+    license = "MIT";
   });
 
   # very simple package depending on moment.js
@@ -42,10 +43,29 @@ let
     '';
   };
 
+  # convert a package.json to yarn2nix package template
+  template = package-json: pkgs.runCommandLocal "generate-template" {} ''
+    ${yarn2nix}/bin/yarn2nix --license-data ${yarn2nix.passthru.licensesJson} \
+      --template ${package-json} > $out
+    echo "template for ${package-json} is:" >&2
+    cat $out >&2
+  '';
+
+  # generates nix expression for license with a given spdx id and imports it
+  spdxLicenseSet = spdx:
+    let
+      packageJson = pkgs.writeText "package.json" (builtins.toJSON {
+        name = "license-test-${spdx}";
+        version = "0.1.0";
+        license = spdx;
+      });
+      tpl = import (template packageJson) {} {};
+    in tpl.meta.license;
+
   # test suite
   tests = runTestsuite "yarn2nix" [
     (it "checks the template output"
-      (let tmpl = nixLib.callPackageJson my-package-json {} {};
+      (let tmpl = import (template my-package-json) {} {};
       in [
       # TODO: this is a naïve match, might want to create a better test
       (assertEq "template" tmpl {
@@ -55,7 +75,9 @@ let
         };
         version = "1.5.3";
         nodeBuildInputs = [];
-        meta = { };
+        meta = {
+          license = pkgs.lib.licenses.mit;
+        };
       })
     ]))
     (it "checks the readme example"
@@ -71,6 +93,20 @@ let
         ".bin" = "directory";
         "moment" = "symlink";
       })]))
+    (it "checks license conversion"
+      (builtins.map
+        (v: assertEq v.spdx (spdxLicenseSet v.spdx) v.set)
+        (with pkgs.lib.licenses; [
+          # TODO recommended attribute name changes in more recent nixpkgs
+          { spdx = "AGPL-3.0-only"; set = agpl3; }
+          { spdx = "GPL-3.0-or-later"; set = gpl3Plus; }
+          { spdx = "MIT"; set = mit; }
+          { spdx = "BSD-3-Clause"; set = bsd3; }
+          { spdx = "ISC"; set = isc; }
+          { spdx = "UNLICENSED"; set = unfree; }
+          # Check that anything else is kept as is
+          { spdx = "See LICENSE.txt"; set = "See LICENSE.txt"; }
+    ])))
   ];
 
   # small helper that checks the output of tests

--- a/yarn2nix.cabal
+++ b/yarn2nix.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7ff6aead541855fbc43b2a956884d777bdec58d05b79e1bafbbdb71ea4824ea7
+-- hash: cd09a515548908f7d48879243299f2f71fd0117b1746ef06467908c5f1a1d3b4
 
 name:           yarn2nix
 version:        0.8.0
@@ -36,6 +36,7 @@ library
   exposed-modules:
       Distribution.Nixpkgs.Nodejs.Cli
       Distribution.Nixpkgs.Nodejs.FromPackage
+      Distribution.Nixpkgs.Nodejs.License
       Distribution.Nixpkgs.Nodejs.OptimizedNixOutput
       Distribution.Nixpkgs.Nodejs.ResolveLockfile
       Distribution.Nixpkgs.Nodejs.RunConfig


### PR DESCRIPTION
The goal of this PR is the same one as #26, but the approach is different: The idea is to do the heavy lifting in `yarn2nix` instead of in the nix expression which saves a lot of headache.

The core idea is to have a `licenses.json` built using `writeText "licenses.json" (builtins.toJSON lib.licenses)` for looking up SPDX identifiers and getting the correct nix expressions for nixpkgs.

This PR depends on #43, so comparing with `arg-parsing` makes for a more readable diff.

Todo:

* [ ] Tests
  * [ ] Haskell test suite (?)
  * [x] Template output
  * [x] against `lib.licenses`
* [x] Handle `UNLICENSED` magic value of `package.json`
* [x] Point the default value of `--license-data` to a `licenses.json` in the nix store in `default.nix` 
  * [x] Decrease size of `licenses.json` by filtering out licenses without a spdx id
* [ ] Add this feature for `yarn.lock` nix expressions as well (?)
* [ ] Update README