### PR TITLE
chore(default.nix): bump nixpkgs

### DIFF
--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,5 +1,5 @@
 import (builtins.fetchTarball {
-  # nixpkgs unstable 2019-05-31
-  url = "https://github.com/NixOS/nixpkgs/archive/c438ce12a858f24c1a2479213eaab751da45fa50.tar.gz";
-  sha256 = "18m4hxx8y0gfrmhkz29iyc0hmss584m9xhgpk7j7bwjaci0fps4z";
+  # nixpkgs unstable 2020-09-29
+  url = "https://github.com/NixOS/nixpkgs/archive/8ed3178bc2050b93ed14d1b0862706f6c8845d08.tar.gz";
+  sha256 = "1mf0ssjpzw4gmi8vfqr4h0c4qfpjv2gzpx5svawb4qpdi1f6fmxs";
 })

--- a/package.yaml
+++ b/package.yaml
@@ -26,16 +26,15 @@ dependencies:
   - base == 4.*
   - bytestring == 0.10.*
   - containers >= 0.5 && < 0.7
-  - data-fix == 0.0.7 || == 0.2.0
+  - data-fix >= 0.0.7 && < 0.4
   - directory == 1.3.*
   - filepath == 1.4.*
-  - hnix == 0.6.*
+  - hnix >= 0.6 && < 0.11
   - mtl == 2.2.*
-  - prettyprinter == 1.2.*
+  - prettyprinter >= 1.2 && < 1.8
   - process >= 1.4
   - protolude == 0.2.*
-  - regex-tdfa == 1.2.*
-  - regex-tdfa-text == 1.0.0.*
+  - regex-tdfa ^>= 1.3
   - stm > 2.4.0 && < 2.6.0.0
   - text == 1.2.*
   - transformers == 0.5.*
@@ -63,7 +62,7 @@ tests:
     main: Test.hs
     source-dirs: tests
     dependencies:
-      - neat-interpolation == 0.3.*
+      - neat-interpolation >= 0.3 && < 0.6
       - protolude == 0.2.*
       - tasty >= 0.11 && < 1.3
       - tasty-hunit >= 0.9 && < 0.11

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,6 @@ with import ./nixpkgs-pinned.nix {};
           async-pool
           ansi-wl-pprint
           regex-tdfa
-          regex-tdfa-text
           neat-interpolation
           tasty-th
           tasty-quickcheck

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, async-pool, base, bytestring, containers
-, data-fix, directory, filepath, hnix, mtl
+, data-fix, directory, filepath, hnix, hpack, mtl
 , neat-interpolation, optparse-applicative, prettyprinter, process
-, protolude, regex-tdfa, regex-tdfa-text, stdenv, stm, tasty
-, tasty-hunit, tasty-quickcheck, tasty-th, text, transformers, unix
+, protolude, regex-tdfa, stdenv, stm, tasty, tasty-hunit
+, tasty-quickcheck, tasty-th, text, transformers, unix
 , unordered-containers, yarn-lock
 }:
 mkDerivation {
@@ -14,21 +14,22 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson async-pool base bytestring containers data-fix directory
     filepath hnix mtl optparse-applicative prettyprinter process
-    protolude regex-tdfa regex-tdfa-text stm text transformers
-    unordered-containers yarn-lock
+    protolude regex-tdfa stm text transformers unordered-containers
+    yarn-lock
   ];
+  libraryToolDepends = [ hpack ];
   executableHaskellDepends = [
     aeson async-pool base bytestring containers data-fix directory
     filepath hnix mtl optparse-applicative prettyprinter process
-    protolude regex-tdfa regex-tdfa-text stm text transformers unix
+    protolude regex-tdfa stm text transformers unix
     unordered-containers yarn-lock
   ];
   testHaskellDepends = [
     aeson async-pool base bytestring containers data-fix directory
     filepath hnix mtl neat-interpolation optparse-applicative
-    prettyprinter process protolude regex-tdfa regex-tdfa-text stm
-    tasty tasty-hunit tasty-quickcheck tasty-th text transformers
-    unordered-containers yarn-lock
+    prettyprinter process protolude regex-tdfa stm tasty tasty-hunit
+    tasty-quickcheck tasty-th text transformers unordered-containers
+    yarn-lock
   ];
   homepage = "https://github.com/Profpatsch/yarn2nix#readme";
   description = "Convert yarn.lock files to nix expressions";


### PR DESCRIPTION
regex-tdfa-text was the offender preventing us from updating, however,
regex-tdfa-text has been merged into regex-tdfa, so we only need to bump
some version constraints.