### PR TITLE
fix(cabal): check in generated cabal2nix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
 
-    - uses: cachix/cachix-action@v6
+    - uses: cachix/cachix-action@v8
       with:
         name: yarn2nix
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,12 @@ jobs:
         name: yarn2nix
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
+    - name: check cabal file up to date (run hpack)
+      run: |
+        nix-shell \
+          -E 'with import ./nixpkgs-pinned.nix {}; mkShell { buildInputs = [ haskellPackages.hpack ]; }' \
+          --run 'hpack && git diff --exit-code'
+
     # Runs a single command using the runners shell
     - name: Build nix-tests
       run: env NIX_PATH= nix-build tests/nix-tests/default.nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /dist-newstyle/
 /result*
 /tests/nix-tests/result*
-/yarn2nix.cabal
 Setup*

--- a/default.nix
+++ b/default.nix
@@ -56,6 +56,7 @@ let
             "src/*"
             "Main.hs"
             "package.yaml"
+            "yarn2nix.cabal"
             ".envrc"
             "shell.nix"
             "Repl.hs"

--- a/yarn2nix.cabal
+++ b/yarn2nix.cabal
@@ -1,0 +1,168 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 7ff6aead541855fbc43b2a956884d777bdec58d05b79e1bafbbdb71ea4824ea7
+
+name:           yarn2nix
+version:        0.8.0
+synopsis:       Convert yarn.lock files to nix expressions
+description:    Convert @yarn.lock@ files to nix expressions. See @yarn2nix@ executable. Contains a nix library to call the generated nix files in @nix-lib/@. Library functions and module names might be restructured in the future.
+category:       Distribution, Nix
+homepage:       https://github.com/Profpatsch/yarn2nix#readme
+bug-reports:    https://github.com/Profpatsch/yarn2nix/issues
+author:         Profpatsch
+maintainer:     mail@profpatsch.de
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    LICENSE
+    README.md
+    yarn2nix.nix
+    default.nix
+    shell.nix
+    nix-lib/buildNodePackage.nix
+    nix-lib/default.nix
+    nix-lib/old-version-dependencies.nix
+
+source-repository head
+  type: git
+  location: https://github.com/Profpatsch/yarn2nix
+
+library
+  exposed-modules:
+      Distribution.Nixpkgs.Nodejs.Cli
+      Distribution.Nixpkgs.Nodejs.FromPackage
+      Distribution.Nixpkgs.Nodejs.OptimizedNixOutput
+      Distribution.Nixpkgs.Nodejs.ResolveLockfile
+      Distribution.Nixpkgs.Nodejs.RunConfig
+      Distribution.Nixpkgs.Nodejs.Utils
+      Distribution.Nodejs.Package
+      Nix.Expr.Additions
+  other-modules:
+      Paths_yarn2nix
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      aeson >=1.0 && <1.5
+    , async-pool ==0.9.*
+    , base ==4.*
+    , bytestring ==0.10.*
+    , containers >=0.5 && <0.7
+    , data-fix >=0.0.7 && <0.4
+    , directory ==1.3.*
+    , filepath ==1.4.*
+    , hnix >=0.6 && <0.11
+    , mtl ==2.2.*
+    , optparse-applicative >=0.13 && <0.16
+    , prettyprinter >=1.2 && <1.8
+    , process >=1.4
+    , protolude ==0.2.*
+    , regex-tdfa >=1.3 && <1.4
+    , stm >2.4.0 && <2.6.0.0
+    , text ==1.2.*
+    , transformers ==0.5.*
+    , unordered-containers ==0.2.*
+    , yarn-lock ==0.6.*
+  default-language: Haskell2010
+
+executable node-package-tool
+  main-is: NodePackageTool.hs
+  other-modules:
+      Paths_yarn2nix
+  ghc-options: -Wall
+  build-depends:
+      aeson >=1.0 && <1.5
+    , async-pool ==0.9.*
+    , base ==4.*
+    , bytestring ==0.10.*
+    , containers >=0.5 && <0.7
+    , data-fix >=0.0.7 && <0.4
+    , directory ==1.3.*
+    , filepath ==1.4.*
+    , hnix >=0.6 && <0.11
+    , mtl ==2.2.*
+    , optparse-applicative >=0.13
+    , prettyprinter >=1.2 && <1.8
+    , process >=1.4
+    , protolude ==0.2.*
+    , regex-tdfa >=1.3 && <1.4
+    , stm >2.4.0 && <2.6.0.0
+    , text ==1.2.*
+    , transformers ==0.5.*
+    , unix ==2.7.*
+    , unordered-containers ==0.2.*
+    , yarn-lock ==0.6.*
+    , yarn2nix
+  default-language: Haskell2010
+
+executable yarn2nix
+  main-is: Main.hs
+  other-modules:
+      Paths_yarn2nix
+  ghc-options: -Wall
+  build-depends:
+      aeson >=1.0 && <1.5
+    , async-pool ==0.9.*
+    , base ==4.*
+    , bytestring ==0.10.*
+    , containers >=0.5 && <0.7
+    , data-fix >=0.0.7 && <0.4
+    , directory ==1.3.*
+    , filepath ==1.4.*
+    , hnix >=0.6 && <0.11
+    , mtl ==2.2.*
+    , optparse-applicative >=0.13 && <0.16
+    , prettyprinter >=1.2 && <1.8
+    , process >=1.4
+    , protolude ==0.2.*
+    , regex-tdfa >=1.3 && <1.4
+    , stm >2.4.0 && <2.6.0.0
+    , text ==1.2.*
+    , transformers ==0.5.*
+    , unordered-containers ==0.2.*
+    , yarn-lock ==0.6.*
+    , yarn2nix
+  default-language: Haskell2010
+
+test-suite yarn2nix-tests
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  other-modules:
+      TestNpmjsPackage
+      Paths_yarn2nix
+  hs-source-dirs:
+      tests
+  ghc-options: -Wall
+  build-depends:
+      aeson >=1.0 && <1.5
+    , async-pool ==0.9.*
+    , base ==4.*
+    , bytestring ==0.10.*
+    , containers >=0.5 && <0.7
+    , data-fix >=0.0.7 && <0.4
+    , directory ==1.3.*
+    , filepath ==1.4.*
+    , hnix >=0.6 && <0.11
+    , mtl ==2.2.*
+    , neat-interpolation >=0.3 && <0.6
+    , optparse-applicative >=0.13 && <0.16
+    , prettyprinter >=1.2 && <1.8
+    , process >=1.4
+    , protolude ==0.2.*
+    , regex-tdfa >=1.3 && <1.4
+    , stm >2.4.0 && <2.6.0.0
+    , tasty >=0.11 && <1.3
+    , tasty-hunit >=0.9 && <0.11
+    , tasty-quickcheck >=0.8 && <0.11
+    , tasty-th ==0.1.7.*
+    , text ==1.2.*
+    , transformers ==0.5.*
+    , unordered-containers ==0.2.*
+    , yarn-lock ==0.6.*
+    , yarn2nix
+  default-language: Haskell2010


### PR DESCRIPTION
hpack is still useful in that it provides a lot of dedup, not checking
in the cabal file is just bad UX.

Also add a CI lint that check whether the file was generated and is up
to date.