### PR TITLE
fix(cli): set --license-data to internal

### DIFF
--- a/src/Distribution/Nixpkgs/Nodejs/Cli.hs
+++ b/src/Distribution/Nixpkgs/Nodejs/Cli.hs
@@ -114,7 +114,9 @@ runConfigParser = RunConfig
   <*> O.optional (O.option O.str
      (O.long "license-data"
    <> O.metavar "FILE"
-   <> O.help "Path to a license.json equivalent to nixpkgs.lib.licenses"))
+   <> O.help "Path to a license.json equivalent to nixpkgs.lib.licenses"
+   -- only really interesting for wrapping at build
+   <> O.internal))
   <*> O.optional (O.argument O.str (O.metavar "FILE"))
 
 runConfigParserWithHelp :: O.ParserInfo RunConfig


### PR DESCRIPTION
We only want to override/wrap it at build time, and telling cabal to
do stuff like this is about as fun as walking on nails.