### PR TITLE
chore(nixpkgs-pinned): 2021-02-25 -> 2021-05-19

### DIFF
--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,7 +1,7 @@
 let
-  # nixpkgs master 2021-02-25
-  rev = "33fe54081404571adf5688e2c405f5a1f1b22ee5";
-  sha256 = "044mdnkj3xqfmw6qg11lp6lw01drras1gfq8vlg8ml685ka7051i";
+  # nixos unstable 2021-05-19
+  rev = "667950d4e8b2e7ae6e9fd67ee7c9de6a3271044f";
+  sha256 = "00g52s3c1fqxpcs7grca7zdw8yb4780ns2jxf73hkiri2ndmd197";
 in
 
 import (builtins.fetchTarball {

--- a/yarn2nix/package.yaml
+++ b/yarn2nix/package.yaml
@@ -37,7 +37,7 @@ dependencies:
   - transformers == 0.5.*
   - unordered-containers == 0.2.*
   - yarn-lock == 0.6.*
-  - optparse-applicative >= 0.13 && < 0.16
+  - optparse-applicative >= 0.16 && < 0.17
 
 library:
   source-dirs: src
@@ -61,7 +61,7 @@ tests:
     dependencies:
       - neat-interpolation >= 0.3 && < 0.6
       - protolude ^>= 0.3
-      - tasty >= 0.11 && < 1.3
+      - tasty >= 0.11 && < 1.5
       - tasty-hunit >= 0.9 && < 0.11
       - tasty-quickcheck >= 0.8 && < 0.11
       - tasty-th == 0.1.7.*

--- a/yarn2nix/src/Distribution/Nixpkgs/Nodejs/Cli.hs
+++ b/yarn2nix/src/Distribution/Nixpkgs/Nodejs/Cli.hs
@@ -126,9 +126,6 @@ runConfigParserWithHelp =
 die' :: Text -> IO a
 die' err = putErrText err *> exitFailure
 
--- TODO from optparse-applicative 0.16.0.0 ShowHelpText
--- accepts an error message as argument, so we can use
--- that instead of putErrText.
 dieWithUsage :: Text -> IO a
 dieWithUsage err = do
   putErrText (err <> "\n")
@@ -136,7 +133,7 @@ dieWithUsage err = do
   hPutStr stderr
     . fst . flip O.renderFailure progn
     $ O.parserFailure optparsePrefs
-        runConfigParserWithHelp O.ShowHelpText mempty
+        runConfigParserWithHelp (O.ShowHelpText Nothing) mempty
   exitFailure
 
 -- TODO refactor

--- a/yarn2nix/yarn2nix.cabal
+++ b/yarn2nix/yarn2nix.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: be4bf10cf8730ee1ae8cb8a03f29c9259d4578507a5dcca48f5bb04deb2f0038
+-- hash: ef678875658edbbf37e1e30d78b959fc9d63bd81de97bc863b8ee9cca1611f73
 
 name:           yarn2nix
 version:        0.8.0
@@ -55,7 +55,7 @@ library
     , filepath ==1.4.*
     , hnix >=0.6 && <0.13
     , mtl ==2.2.*
-    , optparse-applicative >=0.13 && <0.16
+    , optparse-applicative ==0.16.*
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*
@@ -113,7 +113,7 @@ executable yarn2nix
     , filepath ==1.4.*
     , hnix >=0.6 && <0.13
     , mtl ==2.2.*
-    , optparse-applicative >=0.13 && <0.16
+    , optparse-applicative ==0.16.*
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*
@@ -147,13 +147,13 @@ test-suite yarn2nix-tests
     , hnix >=0.6 && <0.13
     , mtl ==2.2.*
     , neat-interpolation >=0.3 && <0.6
-    , optparse-applicative >=0.13 && <0.16
+    , optparse-applicative ==0.16.*
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*
     , regex-tdfa ==1.3.*
     , stm >2.4.0 && <2.6.0.0
-    , tasty >=0.11 && <1.3
+    , tasty >=0.11 && <1.5
     , tasty-hunit >=0.9 && <0.11
     , tasty-quickcheck >=0.8 && <0.11
     , tasty-th ==0.1.7.*


### PR DESCRIPTION
hnix 0.13 seems like a mess currently — we'll just stay with 0.12.* for now.