### PR TITLE
Fix binary name for scoped packages

### DIFF
--- a/yarn2nix/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/yarn2nix/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -22,14 +22,7 @@ depsToPkgKeys :: NP.Dependencies -> [YLT.PackageKey]
 depsToPkgKeys = map toPkgKey . HML.toList
   where
     toPkgKey (k, v) =
-      YLT.PackageKey (parsePackageKeyName k) v
-
-parsePackageKeyName :: Text -> YLT.PackageKeyName
-parsePackageKeyName k =
-  -- we don’t crash on a “wrong” package key to keep this
-  -- code pure, but assume it’s a simple key instead.
-  maybe (YLT.SimplePackageKey k) identity
-    $ YLT.parsePackageKeyName k
+      YLT.PackageKey (NP.parsePackageKeyName k) v
 
 -- | generate a nix expression that translates your package.nix
 --
@@ -40,7 +33,7 @@ genTemplate licSet NP.Package{..} =
   simpleParamSet []
   ==> Param nodeDepsSym
   ==> (mkNonRecSet
-        [ "key" $= packageKeyToSet (parsePackageKeyName name)
+        [ "key" $= packageKeyToSet (NP.parsePackageKeyName name)
         , "version" $= mkStr version
         , "nodeBuildInputs"  $= (letE "a" (mkSym nodeDepsSym)
                                   $ mkList (map (pkgDep "a") depPkgKeys))

--- a/yarn2nix/tests/TestNpmjsPackage.hs
+++ b/yarn2nix/tests/TestNpmjsPackage.hs
@@ -123,6 +123,11 @@ case_binPaths = do
             NP.bin
             (NP.BinFiles $ HML.fromList [ ("foopkg", "./abc") ])
 
+  parseZoom "scoped package"
+            (baseAnd [ ("name", "@foo/bar"), ("bin", "./abc") ])
+            NP.bin
+            (NP.BinFiles $ HML.fromList [ ("bar", "./abc") ])
+
   parseZoom ".directories.bin exists with path"
             (baseAnd [ ("directories", A.object [("bin", "./abc")]) ])
             NP.bin


### PR DESCRIPTION
Fix short form of bin field (`"bin": "./path/to/bin"`) for scoped package where the binary name should be the package name without scope instead of the full name.

For example for `@babel/parser` it should generate a `.bin/parser` link instead of a `.bin/@babel/parser` link.

It probably makes https://github.com/Profpatsch/yarn2nix/pull/45 unnecessary.

(this is my first time writing Haskell so I might have made some newbie mistakes)