### PR TITLE
Yarn-Lock - Fixes yarn.lock for local directory package dependencies

### DIFF
--- a/yarn-lock/src/Yarn/Lock.hs
+++ b/yarn-lock/src/Yarn/Lock.hs
@@ -96,7 +96,7 @@ validatePackage :: Parse.Package
                 -> V.Validation (NE.NonEmpty PackageErrorInfo) (T.Keyed T.Package)
 validatePackage (T.Keyed keys (pos, fields)) = V.eitherToValidation
   $ bimap (pure . PackageErrorInfo pos) (T.Keyed keys)
-    $ File.astToPackage fields
+    $ File.astToPackage keys fields
 
 toLockfile :: [T.Keyed T.Package] -> Either LockfileError T.Lockfile
 toLockfile = pure . File.fromPackages

--- a/yarn-lock/src/Yarn/Lock/File.hs
+++ b/yarn-lock/src/Yarn/Lock/File.hs
@@ -131,7 +131,7 @@ astToPackage pkgKeys = V.validationToEither . validate
     checkRemote :: Parse.PackageFields -> Val T.Remote
     checkRemote fs =
       -- any error is replaced by the generic remote error
-      mToV (pure $ UnknownRemoteType)
+      mToV (pure UnknownRemoteType)
         -- implementing the heuristics of searching for types;
         -- it should of course not lead to false positives
         -- see tests/TestLock.hs

--- a/yarn-lock/src/Yarn/Lock/File.hs
+++ b/yarn-lock/src/Yarn/Lock/File.hs
@@ -29,7 +29,8 @@ import qualified Data.Either.Validation as V
 import qualified Yarn.Lock.Parse as Parse
 import qualified Yarn.Lock.Types as T
 import qualified Data.MultiKeyedMap as MKM
-import Data.Text (Text)
+import Data.Text (Text, stripPrefix)
+import Data.List (find)
 import Data.Bifunctor (first)
 import Control.Monad ((>=>))
 import Control.Applicative ((<|>))
@@ -64,11 +65,17 @@ data FieldParser a = FieldParser
 
 type Val = V.Validation (NE.NonEmpty ConversionError)
 
+-- | True if package key has file: directive in it's spec. Otherwise False. 
+-- For example, "@good-morning/8-am-music@file:./dir": ... 
+-- 
+hasFileLocatorInSpec :: T.PackageKey -> Bool
+hasFileLocatorInSpec pkgKey = "file:" `Text.isPrefixOf` (T.npmVersionSpec pkgKey)
+
 -- | Parse an AST 'PackageFields' to a 'T.Package', which has
 -- the needed fields resolved.
-astToPackage :: Parse.PackageFields
+astToPackage :: NE.NonEmpty T.PackageKey -> Parse.PackageFields
              -> Either (NE.NonEmpty ConversionError) T.Package
-astToPackage = V.validationToEither . validate
+astToPackage pkgKeys = V.validationToEither . validate
   where
     validate :: Parse.PackageFields -> Val T.Package
     validate fs = do
@@ -119,16 +126,16 @@ astToPackage = V.validationToEither . validate
                     npmVersionSpec <- parseField text v
                     pure $ T.PackageKey { name, npmVersionSpec }) }
 
-    -- | Appling heuristics to the field contents to find the
+    -- | Applying heuristics to the field contents to find the
     -- correct remote type.
     checkRemote :: Parse.PackageFields -> Val T.Remote
     checkRemote fs =
       -- any error is replaced by the generic remote error
-      mToV (pure UnknownRemoteType)
+      mToV (pure $ UnknownRemoteType)
         -- implementing the heuristics of searching for types;
         -- it should of course not lead to false positives
         -- see tests/TestLock.hs
-        $ checkGit <|> checkFileLocal <|> checkFile
+        $ checkGit <|> checkFileLocal <|> checkFile <|> checkDir
       where
         mToV :: e -> Maybe a -> V.Validation e a
         mToV err mb = case mb of
@@ -181,6 +188,15 @@ astToPackage = V.validationToEither . validate
           case mayHash of
             Just hash -> pure (T.FileRemote fileUrl hash)
             Nothing   -> pure (T.FileRemoteNoIntegrity fileUrl)
+
+        -- | Valid package without resolved field, for local directory
+        checkDir :: Maybe T.Remote
+        checkDir = do
+          let keyWithDirLocator = find hasFileLocatorInSpec (NE.toList pkgKeys)
+          let dir = stripPrefix "file:" . T.npmVersionSpec =<< keyWithDirLocator
+          case dir of
+            Nothing -> Nothing
+            Just pkgDir -> pure (T.DirectoryLocal pkgDir)
 
         -- | ensure the prefix is removed
         noPrefix :: Text -> Text -> Text

--- a/yarn-lock/src/Yarn/Lock/Types.hs
+++ b/yarn-lock/src/Yarn/Lock/Types.hs
@@ -84,4 +84,8 @@ data Remote
   }
   | FileLocalNoIntegrity
   { fileLocalNoIntegrityPath :: Text -- ^ (relative) path to file on the local machine
-  } deriving (Eq, Show)
+  }
+  | DirectoryLocal
+  { dirLocalPath :: Text -- ^ (relative) path to directory on the local machine
+  } 
+  deriving (Eq, Show)


### PR DESCRIPTION
This PR aims to fix, case where yarn.lock is created by using local directory package. 

For reproduction:

1. `touch package.json`
```
{
    "name": "name",
    "description": "description",
    "version": "0.1.0",
    "private": true,
    "author": "example",
    "license": "UNLICENSED",
    "scripts": {
      "ci:format": "prettier --check './**/*.js{,x}'"
    },
    "dependencies": {
      "custom-plugin": "file:./custom-plugin/"
  }
}
```

2. Install dependencies with `yarn install`
3. It should create following `yarn.lock` file:

```
# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
# yarn lockfile v1


"custom-plugin@file:./custom-plugin":
  version "0.0.0"
```

### What happens currently?

When above `yarn.lock` file is parsed, it leads to: `File.UnknownRemoteType` Error. 

### What this PR does?

It creates new `Remote` type for `DirectoryLocal`. This allows for successful parsing. 