### PR TITLE
Fixes for hnix 0.16

### DIFF
--- a/yarn2nix/package.yaml
+++ b/yarn2nix/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - data-fix >= 0.0.7 && < 0.4
   - directory == 1.3.*
   - filepath == 1.4.*
-  - hnix >= 0.6 && < 0.15
+  - hnix >= 0.6 && < 0.17
   - mtl == 2.2.*
   - prettyprinter >= 1.2 && < 1.8
   - process >= 1.4

--- a/yarn2nix/package.yaml
+++ b/yarn2nix/package.yaml
@@ -22,7 +22,7 @@ dependencies:
   - aeson-better-errors >= 0.9.1.1
   - async-pool == 0.9.*
   - base == 4.*
-  - bytestring == 0.10.*
+  - bytestring >= 0.10 && < 0.12
   - containers >= 0.5 && < 0.7
   - data-fix >= 0.0.7 && < 0.4
   - directory == 1.3.*
@@ -39,7 +39,7 @@ dependencies:
   - transformers == 0.5.*
   - unordered-containers == 0.2.*
   - yarn-lock == 0.6.*
-  - optparse-applicative >= 0.16 && < 0.17
+  - optparse-applicative >= 0.16 && < 0.18
 
 library:
   source-dirs: src

--- a/yarn2nix/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
+++ b/yarn2nix/src/Distribution/Nixpkgs/Nodejs/FromPackage.hs
@@ -8,6 +8,8 @@ module Distribution.Nixpkgs.Nodejs.FromPackage
 
 import Protolude
 
+import Data.Coerce (coerce)
+
 import Nix.Expr
 import Nix.Expr.Additions
 
@@ -35,7 +37,7 @@ genTemplate :: Maybe NL.LicensesBySpdxId -> NP.Package -> NExpr
 genTemplate licSet NP.Package{..} =
   -- reserved for possible future arguments (to prevent breakage)
   simpleParamSet []
-  ==> Param nodeDepsSym
+  ==> Param (coerce nodeDepsSym)
   ==> (mkNonRecSet
         [ "key" $= packageKeyToSet (NP.parsePackageKeyName name)
         , "version" $= mkStr version

--- a/yarn2nix/yarn2nix.cabal
+++ b/yarn2nix/yarn2nix.cabal
@@ -46,14 +46,14 @@ library
     , aeson-better-errors >=0.9.1.1
     , async-pool ==0.9.*
     , base ==4.*
-    , bytestring ==0.10.*
+    , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
     , hnix >=0.6 && <0.15
     , mtl ==2.2.*
-    , optparse-applicative ==0.16.*
+    , optparse-applicative >=0.16 && <0.18
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*
@@ -76,7 +76,7 @@ executable node-package-tool
     , aeson-better-errors >=0.9.1.1
     , async-pool ==0.9.*
     , base ==4.*
-    , bytestring ==0.10.*
+    , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
@@ -108,14 +108,14 @@ executable yarn2nix
     , aeson-better-errors >=0.9.1.1
     , async-pool ==0.9.*
     , base ==4.*
-    , bytestring ==0.10.*
+    , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
     , hnix >=0.6 && <0.15
     , mtl ==2.2.*
-    , optparse-applicative ==0.16.*
+    , optparse-applicative >=0.16 && <0.18
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*
@@ -143,7 +143,7 @@ test-suite yarn2nix-tests
     , aeson-better-errors >=0.9.1.1
     , async-pool ==0.9.*
     , base ==4.*
-    , bytestring ==0.10.*
+    , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
@@ -151,7 +151,7 @@ test-suite yarn2nix-tests
     , hnix >=0.6 && <0.15
     , mtl ==2.2.*
     , neat-interpolation >=0.3 && <0.6
-    , optparse-applicative ==0.16.*
+    , optparse-applicative >=0.16 && <0.18
     , prettyprinter >=1.2 && <1.8
     , process >=1.4
     , protolude ==0.3.*

--- a/yarn2nix/yarn2nix.cabal
+++ b/yarn2nix/yarn2nix.cabal
@@ -51,7 +51,7 @@ library
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
-    , hnix >=0.6 && <0.15
+    , hnix >=0.6 && <0.17
     , mtl ==2.2.*
     , optparse-applicative >=0.16 && <0.18
     , prettyprinter >=1.2 && <1.8
@@ -81,7 +81,7 @@ executable node-package-tool
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
-    , hnix >=0.6 && <0.15
+    , hnix >=0.6 && <0.17
     , mtl ==2.2.*
     , optparse-applicative >=0.13
     , prettyprinter >=1.2 && <1.8
@@ -113,7 +113,7 @@ executable yarn2nix
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
-    , hnix >=0.6 && <0.15
+    , hnix >=0.6 && <0.17
     , mtl ==2.2.*
     , optparse-applicative >=0.16 && <0.18
     , prettyprinter >=1.2 && <1.8
@@ -148,7 +148,7 @@ test-suite yarn2nix-tests
     , data-fix >=0.0.7 && <0.4
     , directory ==1.3.*
     , filepath ==1.4.*
-    , hnix >=0.6 && <0.15
+    , hnix >=0.6 && <0.17
     , mtl ==2.2.*
     , neat-interpolation >=0.3 && <0.6
     , optparse-applicative >=0.16 && <0.18


### PR DESCRIPTION
And adjust bounds for [optparse-applicative, bytestring](https://github.com/Profpatsch/yarn2nix/commit/8b1ff76aa1114207ce13600f4740a2c1ecf96481)